### PR TITLE
Check if host contains a string

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -106,7 +106,21 @@ func ReqHostMatches(regexps ...*regexp.Regexp) ChainedHandler {
 	}
 }
 
-
+// RequestHostContains is a middleware that tests whether the host to which
+// the request is directed to contains one of the given strings.
+//
+func RequestHostContains(hosts ...string) ChainedHandler {
+	return func(chainedHandler Handler) Handler {
+		return HandlerFunc(func(ctx *ProxyCtx) Next {
+			for _, b := range hosts {
+				if strings.Contains(ctx.Req.URL.Host, b) {
+					return chainedHandler.Handle(ctx)
+				}
+			}
+			return NEXT
+		})
+	}
+}
 
 // RequestHostIsIn is a middleware that tests whether the host to which
 // the request is directed to equal to one of the given strings.


### PR DESCRIPTION
adding a contains feature to the filters so exact matches are no longer necessary.
Currently can only check for exact matches, but the additional function allows for the `www.` and the `.com/uk` to be missed off
